### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ sudo: required
 
 language: java
 
+services:
+  - xvfb
+
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:
@@ -38,8 +41,6 @@ install:
   - nvm install v8.11.3 && node --version
 
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm install -g vsce
 
 script:


### PR DESCRIPTION
Looks like Travis changed the xenial build environment making the build to fail:
- oraclejdk8 is not available [anymore](https://github.com/travis-ci/travis-ci/issues/10290)
- they changed the way to start [xvfb](https://benlimmer.com/2019/01/14/travis-ci-xvfb/)