### PR TITLE
Added vuejs as a clientFramework option

### DIFF
--- a/jdl/io.github.jhipster.jdl/src/io/github/jhipster/jdl/config/JdlApplicationOptions.xtend
+++ b/jdl/io.github.jhipster.jdl/src/io/github/jhipster/jdl/config/JdlApplicationOptions.xtend
@@ -25,13 +25,13 @@ import static io.github.jhipster.jdl.config.JdlParameterType.*
 
 /**
  * @author Serano Colameo - Initial contribution and API
- */ 
+ */
 @Singleton
 class JdlApplicationOptions extends JdlAbstractOptions {
-	
+
 	public static val JH_VERSION = 'jhipsterVersion'
 	public static val SERVER_PORT = 'serverPort'
-	
+
 	@Accessors(PUBLIC_GETTER) val static INSTANCE = new JdlApplicationOptions => [
 		val noSqlDbTypes = #['mongodb', 'cassandra', 'couchbase']
 		val prodDbTypes = #['mysql', 'mariadb', 'mssql', 'postgresql', 'oracle', 'no'] + noSqlDbTypes
@@ -41,7 +41,7 @@ class JdlApplicationOptions extends JdlAbstractOptions {
 			new JdlOption('baseName', #['yourBaseName'], AnyLiteral),
 			new JdlOption('buildTool', #['maven', 'gradle']),
 			new JdlOption('cacheProvider', #['ehcache', 'hazelcast', 'infinispan', 'no']),
-			new JdlOption('clientFramework', #['angularX', 'react']),
+			new JdlOption('clientFramework', #['angularX', 'react', 'vuejs']),
 			new JdlOption('clientPackageManager', #['yarn', 'npm']),
 			new JdlOption('databaseType', #['sql', 'mongodb', 'cassandra', 'couchbase', 'no']),
 			new JdlOption('prodDatabaseType', prodDbTypes),


### PR DESCRIPTION
Vue.js support in JHipster is currently implemented via a blueprint, however I expect that this will eventually be integrated to the same level as React.
The clientFramework option allows 2 options (angularx, react), when I enter a value of vuejs I get an error:
{
	"resource": "/e:/hiptest/hiptest.mono.vue/mono.jdl",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "io.github.jhipster.jdl.InvalidParamValue",
	"severity": 8,
	"message": "Unknown literal [vuejs]!",
	"startLineNumber": 40,
	"startColumn": 21,
	"endLineNumber": 40,
	"endColumn": 26
}

This PR prevents the error in the JDL file when clientFramework = vuejs as per sample JDL below:

application {
  config {
    baseName hiptest
    applicationType monolith,
    buildTool maven,
    clientFramework vuejs,
    packageName mono.hiptest,
    authenticationType jwt,
    devDatabaseType	h2Disk,
    prodDatabaseType postgresql,
    useSass true,
    testFrameworks [protractor]
  }
  entities *
}

I tested the change on VSCode, I built the project using mvn package
Then copied the existing VSCode extension and replaced the script and jar files.

