### PR TITLE
Add support for LocalTime data type

### DIFF
--- a/jdl/io.github.jhipster.jdl/src/io/github/jhipster/jdl/JDL.xtext
+++ b/jdl/io.github.jhipster.jdl/src/io/github/jhipster/jdl/JDL.xtext
@@ -150,7 +150,7 @@ JdlDateFieldType:
 	element=JdlDateTypes validators+=JdlDefaultValidator*;
 
 enum JdlDateTypes:
-	Date | LocalDate | ZonedDateTime | Instant | Duration | UUID;
+	Date | LocalDate | ZonedDateTime | Instant | Duration | UUID | LocalTime;
 	
 JdlBlobFieldType:
 	element=JdlBlobTypes validators+=JdlBlobValidator*;


### PR DESCRIPTION
Support for that data type was added in jhipster/generator-jhipster#28474 with JHipster 8.9.0. And now my VS Code complains about the type not existing. So would be nice to get this supported/released. :-)

